### PR TITLE
Fix CSP typo, enable env production, harden zopfli loop, replace deprecated <center> tag

### DIFF
--- a/.github/workflows/build-site-and-docker-image.yml
+++ b/.github/workflows/build-site-and-docker-image.yml
@@ -45,22 +45,24 @@ jobs:
       - name: Compress public static files
         run: |
           cd public
-          for file in $(find . -type f)
-          do
-              zopfli "$file"
-              rm "$file"
-              touch -r "$file".gz "$file"
-          done
+          find . -type f -exec sh -c '
+            for f do
+              zopfli "$f"
+              rm "$f"
+              touch -r "$f".gz "$f"
+            done
+          ' sh {} +
 
       - name: Compress Tor static files
         run: |
           cd tor
-          for file in $(find . -type f)
-          do
-              zopfli "$file"
-              rm "$file"
-              touch -r "$file".gz "$file"
-          done     
+          find . -type f -exec sh -c '
+            for f do
+              zopfli "$f"
+              rm "$f"
+              touch -r "$f".gz "$f"
+            done
+          ' sh {} +
 
       - name: Build and push to Github Packages Docker Registry
         id: docker_build

--- a/.github/workflows/build-site-and-docker-image.yml
+++ b/.github/workflows/build-site-and-docker-image.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Compress public static files
         run: |
           cd public
-          find . -type f -exec sh -c '
+          find . -type f ! -name '*.gz' -exec sh -c '
             for f do
               zopfli "$f"
               rm "$f"
@@ -56,7 +56,7 @@ jobs:
       - name: Compress Tor static files
         run: |
           cd tor
-          find . -type f -exec sh -c '
+          find . -type f ! -name '*.gz' -exec sh -c '
             for f do
               zopfli "$f"
               rm "$f"

--- a/clearnet_config.yml
+++ b/clearnet_config.yml
@@ -14,7 +14,7 @@ minify:
   minifyOutput: true
 
 params:
-  # env: production
+  env: production
   title: sethforprivacy.com
   description: "A simple blog about privacy, Monero, Bitcoin, and self-hosting"
   author: Seth For Privacy

--- a/layouts/shortcodes/video.html
+++ b/layouts/shortcodes/video.html
@@ -1,7 +1,7 @@
-<center>
+<div style="text-align: center;">
     <video preload='{{ .Get "preload" }}' loop muted playsinline aria-label='{{ .Get "label" }}' style='width: {{ .Get "width" }}; height: auto;' controls>
         {{ with .Get "mp4" }}<source src="{{ . }}" type="video/mp4">{{ end }}
         {{ with .Get "webm" }}<source src="{{ . }}" type="video/webm">{{ end }}
         <p> Your browser does not support video. </p>
     </video>
-</center>
+</div>

--- a/nginx.conf
+++ b/nginx.conf
@@ -72,7 +72,7 @@ http {
         add_header Onion-Location http://sfprivg7qec6tdle7u6hdepzjibin6fn3ivm6qlwytr235rh5vc6bfqd.onion$request_uri;
 
         # Block site from being framed with X-Frame-Options and CSP
-        add_header Content-Security-Policy "frame-ancestors 'none'; frame-src 'self; default-src 'none'; media-src 'self'; img-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://github.githubassets.com; form-action; base-uri 'none'; font-src 'self'; connect-src 'self'";
+        add_header Content-Security-Policy "frame-ancestors 'none'; frame-src 'self'; default-src 'none'; media-src 'self'; img-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://github.githubassets.com; form-action; base-uri 'none'; font-src 'self'; connect-src 'self'";
         add_header X-Frame-Options "DENY";
 
         # Security headers


### PR DESCRIPTION
### Changes

- **nginx.conf**: Fix CSP syntax error - `frame-src 'self;` -> `frame-src 'self';` (missing closing quote)
- **clearnet_config.yml**: Uncomment `env: production` so PaperMod renders in production mode
- **build-site-and-docker-image.yml**: Harden zopfli compression loop - use `find -exec` instead of `for file in $(find ...)` which breaks on special characters
- **video.html**: Replace deprecated `<center>` tag with CSS `text-align: center`

See discussion in #homelab for full audit.