### PR TITLE
hardening: pin actions/digests, tighten CSP, rate limit, dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+.git/
+themes/*/.git/
+public/
+tor/
+resources/_gen/
+.github/

--- a/.github/workflows/build-site-and-docker-image.yml
+++ b/.github/workflows/build-site-and-docker-image.yml
@@ -12,36 +12,36 @@ jobs:
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           submodules: recursive  # Fetch Hugo themes (true OR recursive)
           fetch-depth: 0    # Fetch all history for .GitInfo and .Lastmod
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v4
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@v3
+        uses: peaceiris/actions-hugo@2752ce1d29631191ea3f27c23495fa06139a5b78 # v3
         with:
-          hugo-version: 'latest'
+          hugo-version: '0.165.0'
           extended: true
 
       - name: Cache Hugo resources
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6
         with:
           path: |
             resources/_gen
             /home/runner/.cache/hugo_cache
-          key: hugo-${{ hashFiles('hugo.yaml', 'tor_config.yml', 'assets/**', 'layouts/**') }}
+          key: hugo-${{ runner.os }}-${{ github.ref_name }}-${{ hashFiles('hugo.yaml', 'tor_config.yml', 'assets/**', 'layouts/**') }}
           restore-keys: |
-            hugo-
+            hugo-${{ runner.os }}-${{ github.ref_name }}-
 
       - name: Build clearnet
         run: hugo --destination ./public
@@ -74,9 +74,13 @@ jobs:
             done
           ' sh {} +
 
+      - name: Set image creation timestamp
+        id: created
+        run: echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
       - name: Build and push to Github Packages Docker Registry
         id: docker_build
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           push: true
@@ -85,7 +89,7 @@ jobs:
             ghcr.io/${{ github.repository_owner }}/blog:${{ github.sha }}
           labels: |
             org.opencontainers.image.source=${{ github.event.repository.html_url }}
-            org.opencontainers.image.created=${{ steps.prep.outputs.created }}
+            org.opencontainers.image.created=${{ steps.created.outputs.created }}
             org.opencontainers.image.revision=${{ github.sha }}
           cache-from: type=registry,ref=ghcr.io/${{ github.repository_owner }}/blog:latest
           cache-to: type=inline

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginx:alpine@sha256:db35bfc6b2951e7f8a72db5db120288c127ffaeeb4a6d4b95a26fead017d5913
 
 # Upgrade base image
 RUN set -ex && apk --update --no-cache upgrade

--- a/nginx.conf
+++ b/nginx.conf
@@ -31,6 +31,8 @@ http {
 
     # Fix server_names_hash_bucket_size for Tor address
     server_names_hash_bucket_size 128;
+    # Rate limit requests per client IP (10 req/s, burst 20)
+    limit_req_zone $binary_remote_addr zone=main:10m rate=10r/s;
 
     map $sent_http_content_type $expires {
     	default                    off;
@@ -53,6 +55,7 @@ http {
     server {
         listen 0.0.0.0:80;
         server_name sethforprivacy.com;
+        limit_req zone=main burst=20 nodelay;
 
         if ($request_method !~ ^(GET|HEAD|POST)$ ) {
             return 444;
@@ -72,7 +75,7 @@ http {
         add_header Onion-Location http://sfprivg7qec6tdle7u6hdepzjibin6fn3ivm6qlwytr235rh5vc6bfqd.onion$request_uri;
 
         # Block site from being framed with X-Frame-Options and CSP
-        add_header Content-Security-Policy "frame-ancestors 'none'; frame-src 'self'; default-src 'none'; media-src 'self'; img-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://github.githubassets.com; form-action; base-uri 'none'; font-src 'self'; connect-src 'self'";
+        add_header Content-Security-Policy "frame-ancestors 'none'; frame-src 'self'; default-src 'none'; media-src 'self'; img-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; form-action; base-uri 'none'; font-src 'self'; connect-src 'self'";
         add_header X-Frame-Options "DENY";
 
         # Security headers
@@ -94,6 +97,7 @@ http {
         listen 80;
         listen [::]:80;
         server_name sfprivg7qec6tdle7u6hdepzjibin6fn3ivm6qlwytr235rh5vc6bfqd.onion;
+        limit_req zone=main burst=20 nodelay;
 
         if ($request_method !~ ^(GET|HEAD|POST)$ ) {
             return 444;
@@ -111,7 +115,7 @@ http {
         index index.html;
 
         # Block site from being framed with X-Frame-Options and CSP
-        add_header Content-Security-Policy "frame-ancestors 'none'; frame-src 'self'; default-src 'none'; media-src 'self'; img-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://github.githubassets.com; form-action; base-uri 'none'; font-src 'self'; connect-src 'self'";
+        add_header Content-Security-Policy "frame-ancestors 'none'; frame-src 'self'; default-src 'none'; media-src 'self'; img-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; form-action; base-uri 'none'; font-src 'self'; connect-src 'self'";
         add_header X-Frame-Options "DENY";
 
         # Security headers


### PR DESCRIPTION
Removes dead github.githubassets.com style-src origin from both CSPs; adds limit_req (10r/s burst 20) to content vhosts.
SHA-pins all six third-party Actions; fixes broken image.created label; scopes cache restore-keys.
Digest-pins nginx:alpine; adds .dockerignore; pins Hugo to 0.165.0 (stable, extended assets verified).
goldmark unsafe stays true: PaperMod home_info RenderString relies on raw <br/> in hugo.yaml (documented).
Verified: nginx -t inside the pinned nginx:alpine image; Actions SHAs API-peeled; workflow YAML parses.